### PR TITLE
Updates outputs to include registry_server and registry_url

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,15 @@
 
 locals {
-  tmp_dir            = "${path.cwd}/.tmp"
-  registry_url_file  = "${local.tmp_dir}/registry_url.val"
-  registry_namespace = var.registry_namespace != "" ? var.registry_namespace : var.resource_group_name
-  registry_user      = var.registry_user != "" ? var.registry_user : "iamapikey"
-  registry_password  = var.registry_password != "" ? var.registry_password : var.ibmcloud_api_key
-  registry_url       = data.local_file.registry_url.content
-  service            = "container-registry"
-  crn                = "crn:v1:bluemix:public:container-registry:${var.region}:::"
+  tmp_dir              = "${path.cwd}/.tmp/icr"
+  registry_server_file = "${local.tmp_dir}/registry_server.val"
+  registry_region_file = "${local.tmp_dir}/registry_region.val"
+  registry_namespace   = lower(var.registry_namespace != "" ? var.registry_namespace : var.resource_group_name)
+  registry_user        = var.registry_user != "" ? var.registry_user : "iamapikey"
+  registry_password    = var.registry_password != "" ? var.registry_password : var.ibmcloud_api_key
+  registry_server      = data.local_file.registry_server.content
+  registry_region      = data.local_file.registry_region.content
+  service              = "container-registry"
+  crn                  = "crn:v1:bluemix:public:container-registry:${var.region}:::"
 }
 
 resource null_resource ibmcloud_login {
@@ -20,17 +22,29 @@ resource null_resource ibmcloud_login {
   }
 }
 
-# this should probably be moved to a separate module that operates at a namespace level
-resource "null_resource" "create_registry_namespace" {
-  depends_on = [null_resource.ibmcloud_login]
-
+resource null_resource determine_registry_region {
   provisioner "local-exec" {
-    command = "${path.module}/scripts/create-registry-namespace.sh '${local.registry_namespace}' '${var.region}' '${var.upgrade_plan}' '${local.registry_url_file}'"
+    command = "${path.module}/scripts/determine-registry-region.sh '${var.region}' '${local.registry_region_file}'"
   }
 }
 
-data "local_file" "registry_url" {
+data local_file registry_region {
+  depends_on = [null_resource.determine_registry_region]
+
+  filename = local.registry_region_file
+}
+
+# this should probably be moved to a separate module that operates at a namespace level
+resource null_resource create_registry_namespace {
+  depends_on = [null_resource.ibmcloud_login]
+
+  provisioner "local-exec" {
+    command = "${path.module}/scripts/create-registry-namespace.sh '${var.resource_group_name}' '${local.registry_region}' '${local.registry_namespace}' '${var.upgrade_plan}' '${local.registry_server_file}'"
+  }
+}
+
+data local_file registry_server {
   depends_on = [null_resource.create_registry_namespace]
 
-  filename = local.registry_url_file
+  filename = local.registry_server_file
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,9 +36,9 @@ output "label" {
 }
 
 
-output "registry_url" {
-  description = "The url for the container registry endpoint"
-  value       = local.registry_url
+output "registry_server" {
+  description = "The server for the container registry endpoint used in `docker login` command"
+  value       = local.registry_server
 }
 
 output "registry_user" {
@@ -57,5 +57,11 @@ output "registry_password" {
 output "registry_namespace" {
   description = "The namespace for the container registry endpoint"
   value       = local.registry_namespace
+  depends_on = [null_resource.create_registry_namespace]
+}
+
+output "registry_url" {
+  description = "The url of the container registry server that can be accessed by a browser to manage images in the registry"
+  value       = "https://cloud.ibm.com/registry/namespaces?region=${local.registry_region}"
   depends_on = [null_resource.create_registry_namespace]
 }

--- a/scripts/create-registry-namespace.sh
+++ b/scripts/create-registry-namespace.sh
@@ -1,31 +1,14 @@
 #!/usr/bin/env bash
 
 RESOURCE_GROUP="$1"
-REGION="$2"
-UPGRADE_PLAN="$3"
-REGISTRY_URL_FILE="$4"
+REGISTRY_REGION="$2"
+REGISTRY_NAMESPACE="$3"
+UPGRADE_PLAN="$4"
+REGISTRY_SERVER_FILE="$5"
 
-if [[ -z "${RESOURCE_GROUP}" ]] || [[ -z "${REGION}" ]]; then
-  echo "Usage: create-registry-namespace.sh RESOURCE_GROUP REGION [UPGRADE_PLAN] [REGISTRY_URL_FILE]"
+if [[ -z "${RESOURCE_GROUP}" ]] || [[ -z "${REGISTRY_REGION}" ]] || [[ -z "${REGISTRY_NAMESPACE}" ]]; then
+  echo "Usage: create-registry-namespace.sh RESOURCE_GROUP REGISTRY_REGION REGISTRY_NAMESPACE [UPGRADE_PLAN] [REGISTRY_SERVER_FILE]"
   exit 1
-fi
-
-# The name of a registry namespace cannot contain uppercase characters
-# Lowercase the resource group name, just in case...
-REGISTRY_NAMESPACE=$(echo "$RESOURCE_GROUP" | tr '[:upper:]' '[:lower:]')
-
-if [[ "${REGION}" =~ "us-" ]]; then
-  REGISTRY_REGION="us-south"
-elif [[ "${REGION}" == "eu-gb" ]]; then
-  REGISTRY_REGION="uk-south"
-elif [[ "${REGION}" =~ "eu-" ]]; then
-  REGISTRY_REGION="eu-central"
-elif [[ "${REGION}" =~ "jp-" ]]; then
-  REGISTRY_REGION="ap-north"
-elif [[ "${REGION}" =~ "ap-" ]]; then
-  REGISTRY_REGION="ap-south"
-else
-  REGISTRY_REGION="${REGION}"
 fi
 
 ibmcloud cr region-set "${REGISTRY_REGION}"
@@ -39,14 +22,14 @@ else
     echo -e "Registry namespace ${REGISTRY_NAMESPACE} found."
 fi
 
-REGISTRY_URL=$(ibmcloud cr region | grep "icr.io" | sed -E "s/.*'(.*icr.io)'.*/\1/")
-echo "Registry url: ${REGISTRY_URL}"
+REGISTRY_SERVER=$(ibmcloud cr region | grep "icr.io" | sed -E "s/.*'(.*icr.io)'.*/\1/")
+echo "Registry server: ${REGISTRY_SERVER}"
 
-if [[ -n "${REGISTRY_URL_FILE}" ]]; then
-  REGISTRY_URL_PATH=$(dirname "${REGISTRY_URL_FILE}")
-  mkdir -p "${REGISTRY_URL_PATH}"
+if [[ -n "${REGISTRY_SERVER_FILE}" ]]; then
+  REGISTRY_SERVER_PATH=$(dirname "${REGISTRY_SERVER_FILE}")
+  mkdir -p "${REGISTRY_SERVER_PATH}"
 
-  echo -n "${REGISTRY_URL}" > "${REGISTRY_URL_FILE}"
+  echo -n "${REGISTRY_SERVER}" > "${REGISTRY_SERVER_FILE}"
 fi
 
 if [[ "${UPGRADE_PLAN}" == "true" ]]; then

--- a/scripts/determine-registry-region.sh
+++ b/scripts/determine-registry-region.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+REGION="$1"
+REGISTRY_REGION_FILE="$2"
+
+if [[ "${REGION}" =~ "us-" ]]; then
+  REGISTRY_REGION="us-south"
+elif [[ "${REGION}" == "eu-gb" ]]; then
+  REGISTRY_REGION="uk-south"
+elif [[ "${REGION}" =~ "eu-" ]]; then
+  REGISTRY_REGION="eu-central"
+elif [[ "${REGION}" =~ "jp-" ]]; then
+  REGISTRY_REGION="ap-north"
+elif [[ "${REGION}" =~ "ap-" ]]; then
+  REGISTRY_REGION="ap-south"
+else
+  REGISTRY_REGION="${REGION}"
+fi
+
+echo "Registry region (${REGION}): ${REGISTRY_REGION}"
+
+if [[ -n "${REGISTRY_REGION_FILE}" ]]; then
+  REGISTRY_REGION_FILE_PATH=$(dirname "${REGISTRY_REGION_FILE}")
+  mkdir -p "${REGISTRY_REGION_FILE_PATH}"
+
+  echo -n "${REGISTRY_REGION}" > "${REGISTRY_REGION_FILE}"
+fi


### PR DESCRIPTION
- Fixes bug where resource group was not passed correctly to create-registry-namespace
- Renames registry_url output to registry_server - value contains the server/host used to log into the image registry from the command line
- Adds registry_server output with the url used to access the container registry from a browser

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>